### PR TITLE
fix(tests): add request context to app fixture for Flask-Login compat…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,8 @@ def app():
     flask_app.config['LOGIN_DISABLED'] = True
     with flask_app.app_context():
         _db.create_all()
-        yield flask_app
+        with flask_app.test_request_context('/'):
+            yield flask_app
         _db.session.remove()
         _db.drop_all()
 


### PR DESCRIPTION
…ibility

Activity log service calls current_user.is_authenticated inside services. Flask-Login's current_user proxy requires a request context — without it the proxy resolves to None in unit tests (app context only).

Adding test_request_context('/') lets Flask-Login return AnonymousUser so is_authenticated is False instead of raising AttributeError.